### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mysql2": "3.15.2",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
-    "sequelize": "^6.37.7"
+    "sequelize": "^6.37.7",
+    "express-rate-limit": "^8.1.0"
   }
 }

--- a/routes/lists.js
+++ b/routes/lists.js
@@ -1,13 +1,20 @@
 const express = require('express');
+const RateLimit = require('express-rate-limit');
 const { Item, List } = require('../models');
 const router = express.Router();
 const verifyToken = require('../middleware/auth');
+
+// Rate limiter: max 100 requests per 15 minutes per IP
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 
 /**
  * Creation of new list
  * POST /api/lists
  */
-router.post('/', verifyToken, async (req, res) => {
+router.post('/', verifyToken, limiter, async (req, res) => {
     try {
         const { name } = req.body;
         const userId = req.user.id;
@@ -23,7 +30,7 @@ router.post('/', verifyToken, async (req, res) => {
  * Get all lists
  * GET /api/lists
  */
-router.get('/:userId', verifyToken, async (req, res) => {
+router.get('/:userId', verifyToken, limiter, async (req, res) => {
     try {
         const { userId } = req.params;
         if (parseInt(userId) !== req.user.id) {
@@ -41,7 +48,7 @@ router.get('/:userId', verifyToken, async (req, res) => {
  * Get list by id
  * GET /api/lists/:userId/:id
  */
-router.get('/:userId/:id', verifyToken, async (req, res) => {
+router.get('/:userId/:id', verifyToken, limiter, async (req, res) => {
     try {
         const { userId, id } = req.params;
         if (parseInt(userId) !== req.user.id) {
@@ -62,7 +69,7 @@ router.get('/:userId/:id', verifyToken, async (req, res) => {
  * Update list
  * PUT /api/lists/:userId/:id
  */
-router.put('/:userId/:id', verifyToken, async (req, res) => {
+router.put('/:userId/:id', verifyToken, limiter, async (req, res) => {
     try {
         const { userId, id } = req.params;
         if (parseInt(userId) !== req.user.id) {


### PR DESCRIPTION
Potential fix for [https://github.com/Forz70043/shoppingList/security/code-scanning/1](https://github.com/Forz70043/shoppingList/security/code-scanning/1)

To fix this issue, we should add a rate-limiting middleware to the Express router for these endpoints. The standard way in Node.js/Express is to use the `express-rate-limit` package. We'll import it, configure a limiter (e.g., 100 requests per 15 minutes per IP), and apply it to all relevant routes in this router file. This means adding the required import, creating the limiter, and inserting the limiter middleware into every route definition alongside `verifyToken`. Since we can only edit code shown in `routes/lists.js`, we will:

- Import `express-rate-limit` at the top of the file.
- Create a limiter instance (with reasonable defaults).
- Apply the limiter to each route (by including it as a middleware argument between `verifyToken` and the route handler).

No changes to existing logic; only middleware additions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
