### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Forz70043/shoppingList/security/code-scanning/12](https://github.com/Forz70043/shoppingList/security/code-scanning/12)

To address this issue, add an explicit `permissions` block to the workflow definition. The minimal secure permission for a CI workflow that checks out code, installs dependencies, builds, and runs tests is `contents: read` (which allows the workflow to check out code). You should add the following at the top level (just below the `name:` line or just before `jobs:`) so that all jobs inherit this setting. No existing functionality will be altered, and the workflow will retain all necessary access for its steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
